### PR TITLE
add select2 tags to docs

### DIFF
--- a/OpenOversight/app/templates/base.html
+++ b/OpenOversight/app/templates/base.html
@@ -53,6 +53,8 @@
     <!-- Bootstrap -->
     <script src="{{ url_for('static', filename='js/bootstrap.min.js') }}"></script>
 
+    <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
+    <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js" defer></script>
     {% block head %}{% endblock %}
   </head>
 

--- a/OpenOversight/app/templates/edit_document.html
+++ b/OpenOversight/app/templates/edit_document.html
@@ -18,10 +18,48 @@
          {{ wtf.form_field(form.department) }}
          {{ wtf.form_field(form.title) }}
          {{ wtf.form_field(form.description) }}
+         <div class="form-group "><label class="control-label" for="tags">Tags</label>
+            <select class="form-control" id="tags" name="tags[]" multiple="multiple"></select>
+         </div>
          {{ wtf.form_field(form.submit, id="submit", button_map={'submit':'primary'}) }}
       </form>
       <br>
    </div>
 </div>
 
+<script>
+   $(document).ready(function() {
+      $("#tags").select2({
+      tags: true,
+      tokenSeparators: [',', ' '],
+      dataType: 'json',
+      ajax: {
+         url: '/tags',
+         processResults: function(data) {
+            return {
+            results: $.map(data.results, function(obj) {
+               return {
+                  id: obj.id,
+                  text: obj.text
+               };
+            })
+            };
+         }
+         }
+      })
+
+      // Fetch the existing tags and add
+      var tagsSelect = $('#tags');
+      $.ajax({
+         type: 'GET',
+         url: "/tags/documents/{{ document_id }}"
+      }).then(function (data) {
+         // create the option and append to Select2
+         $.each(data.results, function(i, item) {
+            var option = new Option(item.text, item.id, true, true);
+            tagsSelect.append(option).trigger('change');
+         });
+      });
+   });
+</script>
 {% endblock %}

--- a/OpenOversight/app/templates/submit_document.html
+++ b/OpenOversight/app/templates/submit_document.html
@@ -7,6 +7,8 @@
 {% block head %}
 <link href="{{ url_for('static', filename='css/dropzone.css') }}" rel="stylesheet">
 <link href="{{ url_for('static', filename='css/dropzone-override.css') }}" rel="stylesheet">
+<link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
+<script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js" defer></script>
 {% endblock %}
 
 {% block content %}
@@ -20,6 +22,9 @@
          {{ wtf.form_field(form.department) }}
          {{ wtf.form_field(form.title) }}
          {{ wtf.form_field(form.description) }}
+         <div class="form-group "><label class="control-label" for="tags">Tags</label>
+            <select class="form-control" id="tags" name="tags[]" multiple="multiple"></select>
+         </div>
          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
          {{ wtf.form_field(form.file) }}
          <div id="my-cop-dropzone"  class='dropzone'>
@@ -88,5 +93,27 @@
    });
    </script>
 </div>
+<script>
+$(document).ready(function() {
+   $("#tags").select2({
+      tags: true,
+      tokenSeparators: [',', ' '],
+      dataType: 'json',
+      ajax: {
+         url: '/tags',
+         processResults: function(data) {
+            return {
+            results: $.map(data.results, function(obj) {
+               return {
+                  id: obj.id,
+                  text: obj.text
+               };
+            })
+            };
+         }
+      }
+   });
+});
+</script>
 
 {% endblock %}


### PR DESCRIPTION
Relates to #46 but doesn't close it.
added tags db structure in the last pr
This pulls in select2 jquery control and saves/populates it
add ajax queries to views.py
at this point, new and edit docs should create new tags if new entry or use the existing tag id if existing.
Lots of work still to do